### PR TITLE
Add import allowlist enforcement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,23 @@ z = max(1, 5, 3)
 
 ---
 
+## Imports
+
+RRL supports `import` and `from ... import ...` for a limited allowlist of modules. By default, only the following modules are allowed:
+
+* `math`
+* `hardware`
+
+Attempts to import any other module will raise a runtime error.
+
+```rrl
+import math
+from math import sqrt
+import hardware
+```
+
+---
+
 ## If / Elif / Else
 
 Conditional blocks control execution flow.

--- a/rrl.py
+++ b/rrl.py
@@ -8,6 +8,7 @@ from typing import List, Tuple, Optional, Dict, Any
 # RRL : Basic Language Logic
 
 # ========== Safe eval env ==========
+ALLOWED_MODULES = {"math", "hardware"}
 SAFE_BUILTINS = {
     "abs": abs, "min": min, "max": max, "round": round, "len": len,
     "int": int, "float": float, "str": str, "bool": bool, "range": range,
@@ -18,6 +19,15 @@ SAFE_BUILTINS = {
     "object": object, "__name__": "__main__",
 }
 SAFE_GLOBALS = {"__builtins__": SAFE_BUILTINS, "math": math}
+
+def _is_allowed_module(module_name: str) -> bool:
+    return module_name.split(".")[0] in ALLOWED_MODULES
+
+def _guard_import(module_name: str, line: Optional[int] = None) -> None:
+    if _is_allowed_module(module_name):
+        return
+    detail = f"[line {line}] " if line is not None else ""
+    raise RRLRuntimeError(f"{detail}import of '{module_name}' is not allowed")
 
 def safe_eval(expr: str, env: Dict[str, Any]) -> Any:
     return eval(expr, SAFE_GLOBALS, env)
@@ -536,6 +546,7 @@ class Interpreter:
 
         elif isinstance(node, ImportNode):
             for mod, alias in node.modules:
+                _guard_import(mod, line=node.line)
                 try:
                     imported = __import__(mod, fromlist=['*'])
                 except Exception as e:
@@ -544,6 +555,7 @@ class Interpreter:
                 self.env[name] = imported
 
         elif isinstance(node, FromImportNode):
+            _guard_import(node.module, line=node.line)
             for name, alias in node.names:
                 try:
                     mod_obj = __import__(node.module, fromlist=[name])
@@ -812,7 +824,11 @@ def exec_transpiled(source: str, capture_output: Optional[List[str]] = None) -> 
 
     safe_builtins = dict(SAFE_BUILTINS)
     safe_builtins["__build_class__"] = _builtins.__build_class__
-    safe_builtins["__import__"] = _builtins.__import__
+    def _restricted_import(name, globals=None, locals=None, fromlist=(), level=0):
+        _guard_import(name)
+        return _builtins.__import__(name, globals, locals, fromlist, level)
+
+    safe_builtins["__import__"] = _restricted_import
 
     exec_globals = {"__builtins__": safe_builtins, "math": math}
 


### PR DESCRIPTION
### Motivation
- Restrict runtime imports to a small allowlist for safety and predictability when running RRL programs.
- Ensure imports in the interpreter (`ImportNode`/`FromImportNode`) are validated against the same policy to avoid surprises.
- Prevent transpiled Python executed via `exec_transpiled` from bypassing the interpreter allowlist by wrapping `__import__` accordingly.
- Make the allowed modules visible to users by documenting them in `readme.md`.

### Description
- Add `ALLOWED_MODULES` and helper functions `_is_allowed_module` and `_guard_import` to centralize allowlist checks and error reporting.
- Enforce `_guard_import` in the interpreter when handling `ImportNode` and `FromImportNode`, raising `RRLRuntimeError` for disallowed modules.
- Wrap `__import__` in `exec_transpiled` with `_restricted_import` that calls `_guard_import` so transpiled code follows the same allowlist.
- Update `readme.md` to document the import allowlist and show example allowed imports.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bc51668c83209c384189419e1dc6)