### PR TITLE
Add hardware protocol spec and capability handshake

### DIFF
--- a/docs/hardware_protocol.md
+++ b/docs/hardware_protocol.md
@@ -1,0 +1,62 @@
+# Hardware Protocol Specification
+
+## Overview
+This document defines the serial protocol used by RRL hardware adapters (e.g., the Arduino adapter in `hardware.py`).
+It includes message formats, expected responses, and versioning rules.
+
+## Transport
+- **Physical layer:** Serial (e.g., USB serial).
+- **Encoding:** UTF-8 text.
+- **Line endings:** Commands and responses are terminated by `\n` (LF). The adapter is tolerant of missing trailing newlines.
+
+## Protocol Versioning
+- Protocol versions are integer values: `proto=1`, `proto=2`, etc.
+- **Backward compatibility:** Fields may be added to responses; unknown fields must be ignored.
+- **Forward compatibility:** Clients must treat unknown features as unsupported.
+
+## Message Formats
+### Command Format
+Commands are uppercase tokens with optional colon-separated arguments.
+
+```
+COMMAND[:ARG1[:ARG2...]]\n
+```
+
+Examples:
+- `LED_ON:13\n`
+- `MOTOR_START:9:255\n`
+
+### Response Format
+Structured responses use a key-value list prefixed by a response type.
+
+```
+TYPE:key=value;key=value;key=value\n
+```
+
+Example:
+```
+CAPS:proto=1;features=led_on,led_off,motor_start,motor_stop;device=arduino;model=uno\n
+```
+
+## Handshake & Capabilities
+### CAPS Handshake
+- **Command:** `CAPS\n`
+- **Expected response:** `CAPS:proto=<int>;features=<csv>[;device=<str>][;model=<str>][;fw=<str>]\n`
+
+Required fields:
+- `proto`: protocol version integer.
+- `features`: comma-separated feature list in lowercase.
+
+Optional fields:
+- `device`, `model`, `fw` (firmware version), and any future fields.
+
+### Feature Names
+Feature names are lowercase, snake_case tokens used for gating adapter methods:
+- `led_on`
+- `led_off`
+- `motor_start`
+- `motor_stop`
+
+## Error Handling
+- If a device does not support `CAPS`, it may return nothing or an unstructured message.
+- Clients should treat missing or malformed responses as **unknown capabilities** and avoid assuming support for optional features.

--- a/hardware.py
+++ b/hardware.py
@@ -2,7 +2,7 @@ import serial  # for Arduino serial communication
 import time
 
 class Arduino:
-    def __init__(self, port="COM3", baudrate=9600, timeout=1):
+    def __init__(self, port="COM3", baudrate=9600, timeout=1, handshake=True, handshake_timeout=2.0):
         try:
             self.conn = serial.Serial(port, baudrate, timeout=timeout)
             time.sleep(2)  # wait for Arduino to reset
@@ -10,6 +10,10 @@ class Arduino:
         except Exception as e:
             print("[Arduino] Connection failed:", e)
             self.conn = None
+        self.capabilities = {"features": set(), "proto": None, "device": None, "model": None, "fw": None}
+        self.capabilities_known = False
+        if self.conn and handshake:
+            self.handshake(timeout=handshake_timeout)
 
     def write(self, message):
         """Send a message to Arduino."""
@@ -18,27 +22,93 @@ class Arduino:
             print(f"[Arduino] Sent: {message}")
 
     def read(self):
-        """Read a line from Arduino."""
-        if self.conn and self.conn.in_waiting > 0:
-            data = self.conn.readline().decode().strip()
-            print(f"[Arduino] Received: {data}")
-            return data
+        """Read a line from Arduino if available."""
+        return self._read_line(timeout=0)
+
+    def _read_line(self, timeout=1.0):
+        if not self.conn:
+            return None
+        end = time.time() + max(0.0, timeout)
+        while True:
+            if self.conn.in_waiting > 0:
+                data = self.conn.readline().decode().strip()
+                print(f"[Arduino] Received: {data}")
+                return data
+            if time.time() >= end:
+                return None
+            time.sleep(0.05)
+
+    def _parse_caps_response(self, response):
+        if not response or not response.startswith("CAPS:"):
+            return None
+        payload = response[len("CAPS:"):]
+        fields = {}
+        for part in payload.split(";"):
+            if "=" not in part:
+                continue
+            key, value = part.split("=", 1)
+            fields[key.strip()] = value.strip()
+        if "proto" not in fields or "features" not in fields:
+            return None
+        try:
+            proto = int(fields["proto"])
+        except ValueError:
+            return None
+        features = {f.strip() for f in fields["features"].split(",") if f.strip()}
+        return {
+            "proto": proto,
+            "features": features,
+            "device": fields.get("device"),
+            "model": fields.get("model"),
+            "fw": fields.get("fw"),
+        }
+
+    def handshake(self, timeout=2.0):
+        """Query device capabilities using the CAPS command."""
+        if not self.conn:
+            return None
+        self.write("CAPS\n")
+        response = self._read_line(timeout=timeout)
+        parsed = self._parse_caps_response(response)
+        if parsed:
+            self.capabilities = parsed
+            self.capabilities_known = True
+            return parsed
+        self.capabilities_known = False
         return None
+
+    def get_capabilities(self):
+        """Return last known capabilities, if any."""
+        return dict(self.capabilities)
+
+    def supports(self, feature):
+        """Check if a feature is supported."""
+        if not self.capabilities_known:
+            return False
+        return feature in self.capabilities["features"]
+
+    def _require_feature(self, feature):
+        if self.capabilities_known and not self.supports(feature):
+            raise RuntimeError(f"[Arduino] Feature not supported: {feature}")
 
     def led_on(self, pin=13):
         """Turn ON LED at given pin (default 13)."""
+        self._require_feature("led_on")
         self.write(f"LED_ON:{pin}")
 
     def led_off(self, pin=13):
         """Turn OFF LED at given pin (default 13)."""
+        self._require_feature("led_off")
         self.write(f"LED_OFF:{pin}")
 
     def motor_start(self, pin=9, speed=255):
         """Start motor at pin with speed (0-255)."""
+        self._require_feature("motor_start")
         self.write(f"MOTOR_START:{pin}:{speed}")
 
     def motor_stop(self, pin=9):
         """Stop motor at pin."""
+        self._require_feature("motor_stop")
         self.write(f"MOTOR_STOP:{pin}")
 
     def close(self):


### PR DESCRIPTION
### Motivation
- Provide a concise hardware protocol spec so adapters and scripts agree on message formats, responses, and versioning.
- Allow the adapter to advertise and parse supported features so RRL scripts can safely gate hardware calls.
- Improve robustness of serial reads and make capability detection an explicit step during initialization.

### Description
- Add `docs/hardware_protocol.md` describing transport, command/response formats, the `CAPS` handshake, versioning, and feature names.
- Implement a capability handshake in `hardware.py` with `handshake()` and `_parse_caps_response()` that parses `CAPS:...` responses into a capability dict stored on the adapter.
- Expose helpers `get_capabilities()` and `supports()` and add `_require_feature()` to gate `led_on`, `led_off`, `motor_start`, and `motor_stop` calls when capabilities are known.
- Replace the simple `read()` with a timed `_read_line()` helper (and make `read()` call it) and trigger the handshake from `__init__` when `handshake=True`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bc50994c8320b676a83ca702292d)