### PR TITLE
Add HardwareAdapter wrapper for Arduino and expose as env['hardware']

### DIFF
--- a/hardware.py
+++ b/hardware.py
@@ -46,3 +46,76 @@ class Arduino:
         if self.conn:
             self.conn.close()
             print("[Arduino] Connection closed.")
+
+
+class HardwareAdapter:
+    def __init__(self, port="COM3", baudrate=9600, timeout=1):
+        self.arduino = Arduino(port=port, baudrate=baudrate, timeout=timeout)
+
+    def _no_device_error(self):
+        return {
+            "ok": False,
+            "error": {
+                "code": "no_device",
+                "message": "No hardware device connected.",
+            },
+        }
+
+    def _ok(self, **payload):
+        response = {"ok": True}
+        response.update(payload)
+        return response
+
+    def _ensure_connected(self):
+        if not getattr(self.arduino, "conn", None):
+            return self._no_device_error()
+        return None
+
+    def write(self, message):
+        error = self._ensure_connected()
+        if error:
+            return error
+        self.arduino.write(message)
+        return self._ok()
+
+    def read(self):
+        error = self._ensure_connected()
+        if error:
+            return error
+        data = self.arduino.read()
+        return self._ok(data=data)
+
+    def led_on(self, pin=13):
+        error = self._ensure_connected()
+        if error:
+            return error
+        self.arduino.led_on(pin=pin)
+        return self._ok()
+
+    def led_off(self, pin=13):
+        error = self._ensure_connected()
+        if error:
+            return error
+        self.arduino.led_off(pin=pin)
+        return self._ok()
+
+    def motor_start(self, pin=9, speed=255):
+        error = self._ensure_connected()
+        if error:
+            return error
+        self.arduino.motor_start(pin=pin, speed=speed)
+        return self._ok()
+
+    def motor_stop(self, pin=9):
+        error = self._ensure_connected()
+        if error:
+            return error
+        self.arduino.motor_stop(pin=pin)
+        return self._ok()
+
+    def close(self):
+        error = self._ensure_connected()
+        if error:
+            return error
+        self.arduino.close()
+        return self._ok()

--- a/rrl.py
+++ b/rrl.py
@@ -5,6 +5,8 @@ import traceback
 from dataclasses import dataclass
 from typing import List, Tuple, Optional, Dict, Any
 
+from hardware import HardwareAdapter
+
 # RRL : Basic Language Logic
 
 # ========== Safe eval env ==========
@@ -486,6 +488,7 @@ class Interpreter:
         self.env: Dict[str, Any] = {}
         self.output = output
         self.env['robot'] = RobotSim()
+        self.env['hardware'] = HardwareAdapter()
         # helpful collection constructors available in RRL
         self.env['list_of'] = _list_of
         self.env['tuple_of'] = _tuple_of


### PR DESCRIPTION
### Motivation
- Provide a hardware abstraction to centralize Arduino access and avoid printing from low-level code.  
- Make hardware calls available to RRL programs by registering an adapter in the interpreter environment.  
- Ensure callers get structured success/error responses when no physical device is connected instead of raw prints.  
- Forward common hardware operations (LED, motor, read/write, close) through a stable adapter API.

### Description
- Added `HardwareAdapter` to `hardware.py` that wraps `Arduino` and implements `write`, `read`, `led_on`, `led_off`, `motor_start`, `motor_stop`, and `close` forwarding methods.  
- The adapter returns structured responses like `{"ok": False, "error": {"code": "no_device", "message": "No hardware device connected."}}` when no device is connected and `{"ok": True, ...}` on success.  
- Imported `HardwareAdapter` in `rrl.py` and registered an instance in the interpreter environment as `self.env['hardware'] = HardwareAdapter()`.  
- Kept existing `Arduino` behavior and added lightweight connection-checking via `_ensure_connected` to centralize error handling.

### Testing
- No automated tests were executed for these changes.  
- Files were inspected and committed locally after verifying the adapter and registration changes were present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bc502ad08320bf5ee0ec4af632d6)