### PR TITLE
Add Raspberry Pi GPIO support, optional Arduino dependency handling, expand allowlist and docs

### DIFF
--- a/hardware.py
+++ b/hardware.py
@@ -1,15 +1,25 @@
-import serial  # for Arduino serial communication
+import importlib
+import importlib.util
 import time
+
+try:
+    import serial  # for Arduino serial communication
+except Exception:  # pragma: no cover - optional dependency
+    serial = None
 
 class Arduino:
     def __init__(self, port="COM3", baudrate=9600, timeout=1, handshake=True, handshake_timeout=2.0):
-        try:
-            self.conn = serial.Serial(port, baudrate, timeout=timeout)
-            time.sleep(2)  # wait for Arduino to reset
-            print(f"[Arduino] Connected to {port} at {baudrate} baud.")
-        except Exception as e:
-            print("[Arduino] Connection failed:", e)
+        if serial is None:
+            print("[Arduino] pyserial not installed; Arduino unavailable.")
             self.conn = None
+        else:
+            try:
+                self.conn = serial.Serial(port, baudrate, timeout=timeout)
+                time.sleep(2)  # wait for Arduino to reset
+                print(f"[Arduino] Connected to {port} at {baudrate} baud.")
+            except Exception as e:
+                print("[Arduino] Connection failed:", e)
+                self.conn = None
         self.capabilities = {"features": set(), "proto": None, "device": None, "model": None, "fw": None}
         self.capabilities_known = False
         if self.conn and handshake:
@@ -118,9 +128,59 @@ class Arduino:
             print("[Arduino] Connection closed.")
 
 
+class RaspberryPi:
+    def __init__(self, mode="BCM"):
+        self.mode = mode.upper()
+        self.gpio = None
+        self.available = False
+        spec = importlib.util.find_spec("RPi.GPIO")
+        if spec is not None:
+            self.gpio = importlib.import_module("RPi.GPIO")
+            if self.mode == "BOARD":
+                self.gpio.setmode(self.gpio.BOARD)
+            else:
+                self.gpio.setmode(self.gpio.BCM)
+            self.available = True
+
+    def setup_output(self, pin):
+        if not self.available:
+            return False
+        self.gpio.setup(pin, self.gpio.OUT)
+        return True
+
+    def setup_input(self, pin, pull="down"):
+        if not self.available:
+            return False
+        pull = pull.lower()
+        pud = self.gpio.PUD_DOWN if pull == "down" else self.gpio.PUD_UP
+        self.gpio.setup(pin, self.gpio.IN, pull_up_down=pud)
+        return True
+
+    def write(self, pin, value):
+        if not self.available:
+            return False
+        self.gpio.output(pin, self.gpio.HIGH if value else self.gpio.LOW)
+        return True
+
+    def read(self, pin):
+        if not self.available:
+            return None
+        return bool(self.gpio.input(pin))
+
+    def cleanup(self, pin=None):
+        if not self.available:
+            return False
+        if pin is None:
+            self.gpio.cleanup()
+        else:
+            self.gpio.cleanup(pin)
+        return True
+
+
 class HardwareAdapter:
     def __init__(self, port="COM3", baudrate=9600, timeout=1):
         self.arduino = Arduino(port=port, baudrate=baudrate, timeout=timeout)
+        self.raspberry_pi = RaspberryPi()
 
     def _no_device_error(self):
         return {
@@ -139,6 +199,17 @@ class HardwareAdapter:
     def _ensure_connected(self):
         if not getattr(self.arduino, "conn", None):
             return self._no_device_error()
+        return None
+
+    def _ensure_pi(self):
+        if not getattr(self.raspberry_pi, "available", False):
+            return {
+                "ok": False,
+                "error": {
+                    "code": "pi_unavailable",
+                    "message": "Raspberry Pi GPIO not available.",
+                },
+            }
         return None
 
     def write(self, message):
@@ -188,4 +259,39 @@ class HardwareAdapter:
         if error:
             return error
         self.arduino.close()
+        return self._ok()
+
+    def pi_setup_output(self, pin):
+        error = self._ensure_pi()
+        if error:
+            return error
+        self.raspberry_pi.setup_output(pin)
+        return self._ok()
+
+    def pi_setup_input(self, pin, pull="down"):
+        error = self._ensure_pi()
+        if error:
+            return error
+        self.raspberry_pi.setup_input(pin, pull=pull)
+        return self._ok()
+
+    def pi_write(self, pin, value):
+        error = self._ensure_pi()
+        if error:
+            return error
+        self.raspberry_pi.write(pin, value)
+        return self._ok()
+
+    def pi_read(self, pin):
+        error = self._ensure_pi()
+        if error:
+            return error
+        value = self.raspberry_pi.read(pin)
+        return self._ok(value=value)
+
+    def pi_cleanup(self, pin=None):
+        error = self._ensure_pi()
+        if error:
+            return error
+        self.raspberry_pi.cleanup(pin=pin)
         return self._ok()

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ RRL supports `import` and `from ... import ...` for a limited allowlist of modul
 
 * `math`
 * `hardware`
+* `time`
 
 Attempts to import any other module will raise a runtime error.
 
@@ -130,6 +131,70 @@ robot.rotate(90)
 robot.stop()
 display(robot)
 ```
+
+---
+
+## Object-Oriented Programming (OOP)
+
+RRL supports core OOP features including classes, methods, inheritance, and `self`.
+
+```rrl
+class Vehicle
+  def __init__(name)
+    self.name = name
+  enddef
+
+  def label()
+    return "Vehicle: " + self.name
+  enddef
+endclass
+
+class Robot(Vehicle)
+  def __init__(name, speed)
+    self.name = name
+    self.speed = speed
+  enddef
+
+  def label()
+    return "Robot: " + self.name + " @ " + str(self.speed)
+  enddef
+endclass
+
+r = Robot("Atlas", 5)
+display(r.label())
+```
+
+---
+
+## Hardware Integration (Arduino & Raspberry Pi)
+
+The `hardware` module exposes a friendly adapter for Arduino serial devices and Raspberry Pi GPIO. If the device is not available, methods return an error payload instead of raising.
+
+### Arduino
+
+```rrl
+import hardware
+
+result = hardware.led_on(13)
+display(result)
+hardware.motor_start(9, 200)
+hardware.motor_stop(9)
+```
+
+Requires `pyserial` on the host system.
+
+### Raspberry Pi
+
+```rrl
+import hardware
+
+hardware.pi_setup_output(18)
+hardware.pi_write(18, True)
+hardware.pi_write(18, False)
+hardware.pi_cleanup(18)
+```
+
+Requires `RPi.GPIO` on Raspberry Pi systems.
 
 ---
 

--- a/rrl.py
+++ b/rrl.py
@@ -10,7 +10,7 @@ from hardware import HardwareAdapter
 # RRL : Basic Language Logic
 
 # ========== Safe eval env ==========
-ALLOWED_MODULES = {"math", "hardware"}
+ALLOWED_MODULES = {"math", "hardware", "time"}
 SAFE_BUILTINS = {
     "abs": abs, "min": min, "max": max, "round": round, "len": len,
     "int": int, "float": float, "str": str, "bool": bool, "range": range,

--- a/test.rrl
+++ b/test.rrl
@@ -12,5 +12,5 @@ def add(a,b)
  return a+b
 enddef
 display(add(2,3))
-import os as myos
-display(myos.name)
+import time as mytime
+display(mytime.time())


### PR DESCRIPTION
### Motivation

- Prevent the runtime from crashing when optional hardware libraries are not installed by making Arduino support optional and adding Raspberry Pi GPIO integration.  
- Make the language easier to use for hardware projects by exposing a consistent `hardware` adapter API for Arduino and Raspberry Pi.  
- Improve language discoverability and strengthen the OOP story by documenting class/method usage and examples.  
- Allow simple time-based imports in RRL code by expanding the import allowlist.

### Description

- Guard `pyserial` in `hardware.py` so Arduino is optional, and add a new `RaspberryPi` class that detects `RPi.GPIO` via `importlib.util` and provides `setup_output`, `setup_input`, `write`, `read`, and `cleanup` helpers.  
- Extend `HardwareAdapter` to include `raspberry_pi` and new adapter methods `pi_setup_output`, `pi_setup_input`, `pi_write`, `pi_read`, and `pi_cleanup` that return structured error payloads when hardware is unavailable.  
- Add `time` to the interpreter `ALLOWED_MODULES` in `rrl.py` and keep safe global builtins unchanged to permit `import time` usage.  
- Update `readme.md` with an OOP section and hardware usage examples, and update `test.rrl` to exercise `time` import for a simple smoke test.

### Testing

- Ran `python rrl.py test.rrl` as an automated smoke test and verified the program executed and printed expected outputs.  
- Initial run failed with `ModuleNotFoundError: No module named 'serial'`, then `pyserial` import was guarded and `hardware.py` was updated so subsequent runs succeeded.  
- The interpreter/transpiler path was exercised by `test.rrl` which uses `math` and `time` and produced numeric output during the run.  
- No physical hardware was required for the automated test; hardware adapter methods return error payloads when devices or optional libraries are not present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965da9bdf3c83209c10b27e4f0d693b)